### PR TITLE
Add the ability to send the old password as the new one todo

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "1.0.0",
   "description": "NextUP",
   "main": "index.js",
+  "engines": {
+    "npm": "7.0.0",
+    "node": "16.16.0"
+  },
   "scripts": {
     "start": "NODE_ENV=production node ./dist/bin/index.js",
     "dev": "cross-env NODE_ENV=development ts-node-dev ./src/bin/index.ts",

--- a/src/controllers/users/editDashboardSettings.ts
+++ b/src/controllers/users/editDashboardSettings.ts
@@ -13,10 +13,7 @@ export default async (req: Request, res: Response, next: NextFunction): Promise<
 
     res.json({
       message: constants.messages.authResponse.DASHBOARD_VARS_CHANGED,
-      data: {
-        regularVariables: newRegularVariables,
-        encryptedVariables,
-      },
+      data: { ...newRegularVariables, ...encryptedVariables },
     });
   } catch (error) {
     next(error);

--- a/src/helpers/constants.ts
+++ b/src/helpers/constants.ts
@@ -24,7 +24,6 @@ export const messages = {
     resetPassword: 'RESET PASSWORD',
     conflict: 'CONFLICT',
     userStatistics: 'USER STATISTICS',
-    SAME_PASSWORD: 'SAME OLD PASSWORD',
     DASHBOARD_VARS_CHANGED: 'DASHBOARD VARS CHANGED SUCCESSFULLY',
   },
   check: {

--- a/src/services/user/editDashboardSettings.ts
+++ b/src/services/user/editDashboardSettings.ts
@@ -1,6 +1,5 @@
-import { AES, enc } from 'crypto-js';
+import { AES } from 'crypto-js';
 import { Settings, ISettings, IVariables } from 'db-models-nc';
-import { CustomError, constants } from '../../helpers';
 import config from '../../config';
 
 const { ENCRYPTION_SECRET_KEY } = config.server;
@@ -12,27 +11,14 @@ const editDashboardSettings: IEditDashboardSettings = async ({
   regularVariables,
 }) => {
   const oldVars = (await Settings.findOne({ where: { name: 'variables' } })) as ISettings;
-  const oldVarsValue = oldVars.value as IVariables;
-
-  const originalPassword = AES
-    .decrypt(oldVarsValue.encryptedVariables.viewliftPassword, ENCRYPTION_SECRET_KEY)
-    .toString(enc.Utf8);
-
-  if (originalPassword === encryptedVariables.viewliftPassword) {
-    throw new CustomError(
-      constants.messages.authResponse.SAME_PASSWORD,
-      constants.HttpStatus.BAD_REQUEST,
-    );
-  }
-
-  const hashedPassword = AES.encrypt(encryptedVariables.viewliftPassword, ENCRYPTION_SECRET_KEY)
+  const hashedPassword = AES
+    .encrypt(encryptedVariables.viewliftPassword, ENCRYPTION_SECRET_KEY)
     .toString();
 
   oldVars.value = {
     regularVariables,
     encryptedVariables: { viewliftPassword: hashedPassword },
   };
-
   await oldVars.save();
 
   const newDashboardVars = {


### PR DESCRIPTION
## Response body
> Success 200
```json
{
  "message": "DASHBOARD VARS CHANGED SUCCESSFULLY",
  "data": {
    "nextupToOwedSplitPercentage": 1,
    "systemActivationDate": "2022-02-02T00:00:00.000Z",
    "fetchMaxCount": 10,
    "expiredAfterInYears": 23424,
    "viewliftEmail": "ali@g.com",
    "viewliftEndpoint": "https://owiefj.com",
    "viewliftWatchesFetchLimit": 1000,
    "viewliftPassword": "gggggg"
  }
}
```